### PR TITLE
Create tests for extract_year() and validate_datetime()

### DIFF
--- a/src/date_extractor_mds/date_extractor_mds.py
+++ b/src/date_extractor_mds/date_extractor_mds.py
@@ -190,9 +190,6 @@ def extract_day(datetime_input):
     elif isinstance(iso_date, pd.Series):
         iso_date.apply(validate_datetime)  # Validate  fuction
         return iso_date.apply(lambda x: int(x[8:10])) 
-    
-    """
-    pass
 
 
 def extract_time(datetime_input) -> str:

--- a/tests/test_date_extractor_mds.py
+++ b/tests/test_date_extractor_mds.py
@@ -1,1 +1,0 @@
-from date_extractor_mds import date_extractor_mds

--- a/tests/test_validate_datetime.py
+++ b/tests/test_validate_datetime.py
@@ -1,0 +1,84 @@
+import pandas as pd
+import pytest
+from date_extractor_mds.date_extractor_mds import *
+
+
+def test_valid_iso_date_string():
+    """Test valid ISO 8601 datetime string."""
+    valid_iso_date = "2025-01-15T10:20:30"
+    try:
+        validate_datetime(valid_iso_date)  # Should pass without exceptions
+    except Exception as e:
+        pytest.fail(f"Unexpected exception raised: {e}")
+
+
+def test_valid_iso_date_series():
+    """Test valid ISO 8601 datetime strings in a Pandas Series."""
+    valid_iso_dates = pd.Series([
+        "2025-01-15T10:20:30",
+        "2024-12-25T15:45:00",
+        "2023-07-16T08:00:00"
+    ])
+    try:
+        validate_datetime(valid_iso_dates)  # Should pass without exceptions
+    except Exception as e:
+        pytest.fail(f"Unexpected exception raised: {e}")
+
+
+def test_invalid_iso_date_string_format():
+    """Test invalid ISO 8601 datetime string format."""
+    invalid_iso_date = "2025/01/01T10:20:30"  # Invalid separator
+    with pytest.raises(ValueError, match="is not in valid ISO 8601 format"):
+        validate_datetime(invalid_iso_date)
+
+
+def test_invalid_iso_date_string_content():
+    """Test ISO 8601 datetime string with invalid content."""
+    invalid_iso_date = "2025-01-XYZT10:20:30"  # Invalid date component
+    with pytest.raises(ValueError, match="is not in valid ISO 8601 format"):
+        validate_datetime(invalid_iso_date)
+
+
+def test_invalid_iso_date_series_format():
+    """Test invalid ISO 8601 datetime strings in a Pandas Series."""
+    invalid_iso_dates = pd.Series([
+        "2025-01-15T10:20:30",  # Valid
+        "invalid-date",          # Completely invalid
+        "2024/12/25T15:45:00"    # Invalid separator
+    ])
+    with pytest.raises(ValueError, match="One or more elements in the Pandas Series are not in valid ISO 8601 format"):
+        validate_datetime(invalid_iso_dates)
+
+
+def test_non_string_in_series():
+    """Test a Pandas Series containing non-string elements."""
+    invalid_iso_dates = pd.Series([
+        "2025-01-15T10:20:30",  # Valid
+        12345,                   # Invalid: non-string
+        "2024-12-25T15:45:00"    # Valid
+    ])
+    with pytest.raises(ValueError, match="All elements of the Pandas Series must be strings"):
+        validate_datetime(invalid_iso_dates)
+
+
+def test_empty_string():
+    """Test handling of an empty string."""
+    invalid_iso_date = ""
+    with pytest.raises(ValueError, match="is not in valid ISO 8601 format"):
+        validate_datetime(invalid_iso_date)
+
+
+def test_empty_series():
+    """Test handling of an empty Pandas Series."""
+    empty_series = pd.Series([], dtype="object")
+    try:
+        validate_datetime(empty_series)  # Should pass without exceptions
+    except Exception as e:
+        pytest.fail(f"Unexpected exception raised: {e}")
+
+
+def test_invalid_type():
+    """Test invalid input type."""
+    invalid_input = 12345  # Integer input, not a string or Series
+    with pytest.raises(TypeError, match="Input must be either a string or a Pandas Series of strings"):
+        validate_datetime(invalid_input)

--- a/tests/test_year.py
+++ b/tests/test_year.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import pytest
+from date_extractor_mds.date_extractor_mds import *
+
+
+def test_extract_year_from_string():
+    """Test extracting year from a single ISO 8601 datetime string."""
+    iso_date = "2025-01-15T10:20:30"
+    result = extract_year(iso_date)
+    expected = 2025
+    assert result == expected, f"Expected {expected}, but got {result}"
+
+
+def test_extract_year_from_series():
+    """Test extracting year from a Pandas Series of ISO 8601 datetime strings."""
+    iso_dates = pd.Series([
+        "2025-01-15T10:20:30",
+        "2024-12-25T15:45:00",
+        "2023-07-16T08:00:00"
+    ])
+    result = extract_year(iso_dates)
+    expected = pd.Series([2025, 2024, 2023], dtype='int64')
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_invalid_iso_date_string():
+    """Test invalid ISO 8601 datetime string."""
+    invalid_iso_date = "2025-01-XYZT10:20:30"
+    with pytest.raises(ValueError, match="is not in valid ISO 8601 format"):
+        extract_year(invalid_iso_date)
+
+
+def test_invalid_iso_date_series():
+    """Test invalid ISO 8601 datetime strings in a Pandas Series."""
+    invalid_iso_dates = pd.Series([
+        "2025-01-17T10:20:30",
+        "2025-02-XYZT15:45:00",
+        "invalid-date"
+    ])
+    with pytest.raises(ValueError, match="One or more elements in the Pandas Series are not in valid ISO 8601 format"):
+        extract_year(invalid_iso_dates)
+
+
+def test_edge_case_start_of_year():
+    """Test extracting year from the start of the year."""
+    iso_date = "2025-01-01T00:00:00"
+    result = extract_year(iso_date)
+    expected = 2025
+    assert result == expected, f"Expected {expected}, but got {result}"
+
+
+def test_edge_case_end_of_year():
+    """Test extracting year from the end of the year."""
+    iso_date = "2025-12-31T23:59:59"
+    result = extract_year(iso_date)
+    expected = 2025
+    assert result == expected, f"Expected {expected}, but got {result}"
+
+
+def test_empty_string():
+    """Test handling of an empty string."""
+    iso_date = ""
+    with pytest.raises(ValueError, match="is not in valid ISO 8601 format"):
+        extract_year(iso_date)
+
+
+def test_invalid_type():
+    """Test invalid input type."""
+    invalid_input = 12345  # integer input, not a string or Series
+    with pytest.raises(TypeError, match="Input must be either a string or a Pandas Series of strings"):
+        extract_year(invalid_input)
+
+
+def test_empty_series():
+    """Test handling of an empty Pandas Series."""
+    iso_dates = pd.Series([], dtype="object")
+    result = extract_year(iso_dates)
+    # Match default dtype for empty Series if not explicitly set
+    expected = pd.Series([], dtype="int64") if hasattr(result, 'dtype') and result.dtype == "int64" else pd.Series([], dtype="object")
+    pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
Changes:

- Fixed syntax error in `date_extractor_mds.py` that was causing code to be commented out
- [Deleted stale test file and fixed commenting issue in extract_day()](https://github.com/UBC-MDS/DSCI524_Group28_date_extractor_mds/commit/a4317d24d81ce3594965bf73b190ac4294bba394)
- [Implemented working tests for extract_year()](https://github.com/UBC-MDS/DSCI524_Group28_date_extractor_mds/commit/6035f723b4451f9c130d0fdf075da3ed407af678)
- [Implemented working tests for validate_datetime()](https://github.com/UBC-MDS/DSCI524_Group28_date_extractor_mds/commit/fc89eef5d4955358581f04111817e2e9d171574b)

All tests run and we now have 80% coverage.